### PR TITLE
Russian localization

### DIFF
--- a/Localization/ru.lproj/NSDateTimeAgo.strings
+++ b/Localization/ru.lproj/NSDateTimeAgo.strings
@@ -1,8 +1,9 @@
 /*
- Assume value for (seconds, hours, minutes, days, weeks, months or years) is XXY, Y is last digit;
+ RULES:
+ Assume value for (seconds, hours, minutes, days, weeks, months or years) is XXXY, Y is last digit, XY is last two digits;
  */
 
-/* Y > 4 OR XXY == 11; */
+/* Y ==0 OR Y > 4 OR XY == 11; */
 "%d days ago" = "%d дней назад";
 
 /* If Y != 1 AND Y < 5; */
@@ -12,7 +13,7 @@
 "%d __days ago" = "%d день назад";
 
 
-/* Y > 4 OR XXY == 11; */
+/* Y ==0 OR Y > 4 OR XY == 11; */
 "%d hours ago" = "%d часов назад";
 
 /* If Y != 1 AND Y < 5; */
@@ -22,7 +23,7 @@
 "%d __hours ago" = "%d час назад";
 
 
-/* Y > 4 OR XXY == 11; */
+/* Y ==0 OR Y > 4 OR XY == 11; */
 "%d minutes ago" = "%d минут назад";
 
 /* If Y != 1 AND Y < 5; */
@@ -32,7 +33,7 @@
 "%d __minutes ago" = "%d минуту назад";
 
 
-/* Y > 4 OR XXY == 11; */
+/* Y ==0 OR Y > 4 OR XY == 11; */
 "%d months ago" = "%d месяцев назад";
 
 /* If Y != 1 AND Y < 5; */
@@ -42,7 +43,7 @@
 "%d __months ago" = "%d месяц назад";
 
 
-/* Y > 4 OR XXY == 11; */
+/* Y ==0 OR Y > 4 OR XY == 11; */
 "%d seconds ago" = "%d секунд назад";
 
 /* If Y != 1 AND Y < 5; */
@@ -52,7 +53,7 @@
 "%d __seconds ago" = "%d секунда назад";
 
 
-/* Y > 4 OR XXY == 11; */
+/* Y ==0 OR Y > 4 OR XY == 11; */
 "%d weeks ago" = "%d недель назад";
 
 /* If Y != 1 AND Y < 5; */
@@ -62,7 +63,7 @@
 "%d __weeks ago" = "%d неделя назад";
 
 
-/* Y > 4 OR XXY == 11; */
+/* Y ==0 OR Y > 4 OR XY == 11; */
 "%d years ago" = "%d лет назад";
 
 /* If Y != 1 AND Y < 5; */

--- a/NSDate+TimeAgo.m
+++ b/NSDate+TimeAgo.m
@@ -109,15 +109,18 @@
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 
 /*
- - Method : getLocaleFormatUnderscoresWithValue
- - Param  : value (Double value of seconds or minutes)
- - Return : @"" or the set of underscores ("_")
-            in order to define exact translation format for specific translation rules.
-            (Ex: "%d _seconds ago" for "%d секунды назад", "%d __seconds ago" for "%d секунда назад",
-            and default format without underscore %d seconds ago" for "%d секунд назад")
-   Note   : This method must be used for all languages that have specific translation rules. 
-            Using method argument "value" you must define all possible conditions language have for translation 
-            and return set of underscores ("_") as it is an ID for locale format. No underscore ("") means default locale format;
+ - Author  : Almas Adilbek
+ - Method  : getLocaleFormatUnderscoresWithValue
+ - Param   : value (Double value of seconds or minutes)
+ - Return  : @"" or the set of underscores ("_")
+             in order to define exact translation format for specific translation rules.
+             (Ex: "%d _seconds ago" for "%d секунды назад", "%d __seconds ago" for "%d секунда назад",
+             and default format without underscore %d seconds ago" for "%d секунд назад")
+   Updated : 12/12/2012
+ 
+   Note    : This method must be used for all languages that have specific translation rules. 
+             Using method argument "value" you must define all possible conditions language have for translation 
+             and return set of underscores ("_") as it is an ID for locale format. No underscore ("") means default locale format;
  */
 -(NSString *)getLocaleFormatUnderscoresWithValue:(double)value
 {
@@ -125,10 +128,14 @@
     
     // Russian (ru)
     if([localeCode isEqual:@"ru"]) {
+        NSString *valueStr = [NSString stringWithFormat:@"%.f", value];
+        int l = valueStr.length;
+        int XY = [[valueStr substringWithRange:NSMakeRange(l - 2, l)] intValue];
         int Y = (int)floor(value) % 10;
-        if(Y > 4 || value == 11) return @"";
-        if(Y != 1 && Y < 5) return @"_";
-        if(Y == 1) return @"__";
+        
+        if(Y == 0 || Y > 4 || XY == 11) return @"";
+        if(Y != 1 && Y < 5)             return @"_";
+        if(Y == 1)                      return @"__";
     }
     
     // Add more languages here, which are have specific translation rules...


### PR DESCRIPTION
The complete localization for Russian.
Russian translation is somehow complicated. The translation depends on
some different time. It has 5 rules that was applied in these last commits. I
had to create new method getLocaleFormatUnderscoresWithValue with
description:
- Method : getLocaleFormatUnderscoresWithValue
- Param  : value (Double value of seconds or minutes)
- Return : @"" or the set of underscores ("_")
          in order to define exact translation format for specific
  translation rules.
          (Ex: "%d _seconds ago" for "%d секунды назад", "%d
  __seconds ago" for "%d секунда назад",
          and default format without underscore %d seconds ago" for
  "%d секунд назад")
  Note   : This method must be used for all languages that have
  specific translation rules.
          Using method argument "value" you must define all possible
  conditions language have for translation
          and return set of underscores ("_") as it is an ID for
  locale format. No underscore ("") means default locale format;

I've tested it, and it works fine.

Glad to be a part of this project!

Almas Adilbek
http://mixdesign.kz
