### PR TITLE
Added missing translations for Finnish localizable strings. Improved Finnish translation of Just Now.

### DIFF
--- a/NSDateTimeAgo.bundle/fi.lproj/NSDateTimeAgo.strings
+++ b/NSDateTimeAgo.bundle/fi.lproj/NSDateTimeAgo.strings
@@ -26,7 +26,7 @@
 "An hour ago" = "Tunti sitten";
 
 /* No comment provided by engineer. */
-"Just now" = "Nyt";
+"Just now" = "Juuri äsken";
 
 /* No comment provided by engineer. */
 "Last month" = "Viime kuussa";
@@ -41,31 +41,31 @@
 "Yesterday" = "Eilen";
 
 /* No comment provided by engineer. */
-"1 year ago" = "1 year ago";
+"1 year ago" = "Vuosi sitten";
 
 /* No comment provided by engineer. */
-"1 month ago" = "1 month ago";
+"1 month ago" = "Kuukausi sitten";
 
 /* No comment provided by engineer. */
-"1 week ago" = "1 week ago";
+"1 week ago" = "Viikko sitten";
 
 /* No comment provided by engineer. */
-"1 day ago" = "1 day ago";
+"1 day ago" = "Vuorokausi sitten";
 
 /* No comment provided by engineer. */
-"This morning" = "This morning";
+"This morning" = "Tänä aamuna";
 
 /* No comment provided by engineer. */
-"This afternoon" = "This afternoon";
+"This afternoon" = "Tänä iltapäivänä";
 
 /* No comment provided by engineer. */
-"Today" = "Today";
+"Today" = "Tänään";
 
 /* No comment provided by engineer. */
-"This week" = "This week";
+"This week" = "Tällä viikolla";
 
 /* No comment provided by engineer. */
-"This month" = "This month";
+"This month" = "Tässä kuussa";
 
 /* No comment provided by engineer. */
-"This year" = "This year";
+"This year" = "Tänä vuonna";


### PR DESCRIPTION
A tester noticed that some of the Finnish relative time phrases appeared in English. It turned out that almost half of them were not translated, so as a native Finnish speaker I translated them. Also, I improved the translation of the "Just Now" string to be more idiomatic and in line with iOS 7.
