### PR TITLE
Update Traditional Chinese Translation: zh-Hant.lproj/NSDateTimeAgo.strings (can't merge)

### DIFF
--- a/NSDateTimeAgo.bundle/zh-Hant.lproj/NSDateTimeAgo.strings
+++ b/NSDateTimeAgo.bundle/zh-Hant.lproj/NSDateTimeAgo.strings
@@ -1,29 +1,29 @@
 /* No comment provided by engineer. */
-"%d days ago" = "%d 日前";
+"%d days ago" = "%d天前";
 
 /* No comment provided by engineer. */
-"%d hours ago" = "%d 小時前";
+"%d hours ago" = "%d小時前";
 
 /* No comment provided by engineer. */
-"%d minutes ago" = "%d 分鐘前";
+"%d minutes ago" = "%d分鐘前";
 
 /* No comment provided by engineer. */
-"%d months ago" = "%d 個月前";
+"%d months ago" = "%d個月前";
 
 /* No comment provided by engineer. */
-"%d seconds ago" = "%d 秒前";
+"%d seconds ago" = "%d秒鐘前";
 
 /* No comment provided by engineer. */
-"%d weeks ago" = "%d 星期前";
+"%d weeks ago" = "%d星期前";
 
 /* No comment provided by engineer. */
-"%d years ago" = "%d 年前";
+"%d years ago" = "%d年前";
 
 /* No comment provided by engineer. */
-"A minute ago" = "1 分鐘前";
+"A minute ago" = "1分鐘前";
 
 /* No comment provided by engineer. */
-"An hour ago" = "1 小時前";
+"An hour ago" = "1小時前";
 
 /* No comment provided by engineer. */
 "Just now" = "剛剛";
@@ -35,37 +35,37 @@
 "Last week" = "上星期";
 
 /* No comment provided by engineer. */
-"Last year" = "上年";
+"Last year" = "去年";
 
 /* No comment provided by engineer. */
 "Yesterday" = "昨天";
 
 /* No comment provided by engineer. */
-"1 year ago" = "1 年前";
+"1 year ago" = "1年前";
 
 /* No comment provided by engineer. */
-"1 month ago" = "1 個月前";
+"1 month ago" = "1個月前";
 
 /* No comment provided by engineer. */
-"1 week ago" = "1 星期前";
+"1 week ago" = "1星期前";
 
 /* No comment provided by engineer. */
-"1 day ago" = "1 日前";
+"1 day ago" = "1天前";
 
 /* No comment provided by engineer. */
-"This morning" = "今早";
+"This morning" = "今天上午";
 
 /* No comment provided by engineer. */
 "This afternoon" = "今天下午";
 
 /* No comment provided by engineer. */
-"Today" = "今日";
+"Today" = "今天";
 
 /* No comment provided by engineer. */
-"This week" = "這星期";
+"This week" = "本週";
 
 /* No comment provided by engineer. */
-"This month" = "這個月";
+"This month" = "本月";
 
 /* No comment provided by engineer. */
 "This year" = "今年";


### PR DESCRIPTION
1.Modified some translation, to make it more formal/suitable/understandable for Chinese users.
2.According to Chinese Reading Habit: Usually, there is no "space" between characters.
For example:
We usually take "1 day ago" as "1天前", not "1 天前". The space after "1" feels a little uncomfortable/machine-generated. "1天前" feels more natural:)
