### PR TITLE
fix non gregorian system calendar

### DIFF
--- a/NSDate+TimeAgo.m
+++ b/NSDate+TimeAgo.m
@@ -127,7 +127,7 @@ NSLocalizedStringFromTableInBundle(key, @"NSDateTimeAgo", [NSBundle bundleWithPa
 // Similar to timeAgo, but only returns "
 - (NSString *)dateTimeAgo
 {
-    NSCalendar *calendar = [NSCalendar currentCalendar];
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     NSDate * now = [NSDate date];
     NSDateComponents *components = [calendar components:
                                     NSCalendarUnitYear|
@@ -203,7 +203,7 @@ NSLocalizedStringFromTableInBundle(key, @"NSDateTimeAgo", [NSBundle bundleWithPa
 - (NSString *)dateTimeUntilNow
 {
     NSDate * now = [NSDate date];
-    NSCalendar *calendar = [NSCalendar currentCalendar];
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     
     NSDateComponents *components = [calendar components:NSCalendarUnitHour
                                                fromDate:self


### PR DESCRIPTION
I have a problem that don't return correctlly time if I use non gregorian calendar.(ex: setting `Settings > General > Language & Region > Calendar > Japanese.`)

this PR is fix that.

