### PR TITLE
Support dynamic frameworks through cocoapods

### DIFF
--- a/NSDate+TimeAgo.m
+++ b/NSDate+TimeAgo.m
@@ -4,11 +4,18 @@
 -(NSString *)getLocaleFormatUnderscoresWithValue:(double)value;
 @end
 
+@interface DummyClass: NSObject
+@end
+
+@implementation DummyClass
+
+@end
+
 @implementation NSDate (TimeAgo)
 
 #ifndef NSDateTimeAgoLocalizedStrings
 #define NSDateTimeAgoLocalizedStrings(key) \
-NSLocalizedStringFromTableInBundle(key, @"NSDateTimeAgo", [NSBundle bundleWithPath:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"NSDateTimeAgo.bundle"]], nil)
+NSLocalizedStringFromTableInBundle(key, @"NSDateTimeAgo", [NSBundle bundleWithPath:[[[NSBundle bundleForClass:[DummyClass class]] resourcePath] stringByAppendingPathComponent:@"NSDateTimeAgo.bundle"]], nil)
 #endif
 
 // shows 1 or two letter abbreviation for units.


### PR DESCRIPTION
Cocoapods guide pointing to the usage of `+[NSBundle bundleForClass:]`: http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/

Fixes #64 crash