### PR TITLE
"ru" & "uk" locale code bug fixed. Added Ukrainian to Objective-C framework.

### DIFF
--- a/NSDate+Extension.swift
+++ b/NSDate+Extension.swift
@@ -153,7 +153,7 @@ extension NSDate {
         }
         
         // Russian (ru) and Ukrainian (uk)
-        if localeCode == "ru" || localeCode == "uk" {
+        if localeCode.hasPrefix("ru") || localeCode.hasPrefix("uk") {
             let XY = Int(floor(value)) % 100
             let Y = Int(floor(value)) % 10
 

--- a/NSDate+TimeAgo.m
+++ b/NSDate+TimeAgo.m
@@ -363,7 +363,7 @@ NSLocalizedStringFromTableInBundle(key, @"NSDateTimeAgo", [NSBundle bundleWithPa
     NSString *localeCode = [[NSLocale preferredLanguages] objectAtIndex:0];
     
     // Russian (ru)
-    if([localeCode isEqual:@"ru"]) {
+    if([localeCode hasPrefix:@"ru"] || [localeCode hasPrefix:@"uk"]) {
         int XY = (int)floor(value) % 100;
         int Y = (int)floor(value) % 10;
         


### PR DESCRIPTION
1. As Apple has changed locale code format, we need to compare not whole locale code but only prefix of it.
2. Added Ukrainian to Objective-C framework according to Swift code.